### PR TITLE
Catch reprojection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0
+
+ - Handle tif reprojection errors as `EVALID`
+
 ## 0.4.0
 
  - Upgraded to node-gdal@0.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.5.0
+## 0.4.1
 
  - Handle tif reprojection errors as `EVALID`
 

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,14 @@
+# Contributing
+
+General guidelines for contributing to node-wmtiff. 
+
+## Releasing
+
+To release a new node-wmtiff version:
+
+ - Make sure that all tests as passing (including travis tests).
+ - Update the CHANGELOG.md
+ - Make a "bump commit" by updating the version in `package.json` and adding a commit like `-m "bump to v0.8.5"`
+ - Create a github tag like `git tag -a v0.8.5 -m "v0.8.5" && git push --tags`
+ - Ensure travis tests are passing
+ - Then publish the module to npm repositories by running `npm publish`

--- a/index.js
+++ b/index.js
@@ -65,7 +65,11 @@ function reproject(srcpath, dstpath) {
   options.dst.geoTransform = info.geoTransform;
   options.dst.srs = options.t_srs;
 
-  gdal.reprojectImage(options);
+  try {
+    gdal.reprojectImage(options);
+  } catch (err) {
+    throw new Error('GDAL Reprojection Error');
+  }
 
   var colorInterps = getColorInterpretation(src);
   var noDataValues = getNoDataValues(src);

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function reproject(srcpath, dstpath) {
   try {
     gdal.reprojectImage(options);
   } catch (err) {
-    throw new Error('GDAL Reprojection Error');
+    throw new Error('GDAL Reprojection Error ' + err.message);
   }
 
   var colorInterps = getColorInterpretation(src);

--- a/test/test.js
+++ b/test/test.js
@@ -60,3 +60,19 @@ tape('teardown', function(assert) {
   });
 
 });
+
+tape('reprojection error', function(assert) {
+  var datadir = path.join(__dirname, 'fixtures');
+  var srcpath = path.join(datadir, 'invalid-reprojection.tif');
+  var dstpath = path.join(datadir, 'invalid-reprojection-attempt.tif');
+
+  assert.throws(function(){wmtiff.reproject(srcpath, dstpath)},Error, "tif GDAL Reprojection Fails");
+  fs.unlink(dstpath);
+  assert.end();
+
+});
+
+  
+        
+
+


### PR DESCRIPTION
Adds a try/catch to handle reprojection errors from GDAL. See #12. 