### PR TITLE
Add try catch for gdal bounds error

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,11 @@ function reproject(srcpath, dstpath) {
     options: ['NUM_THREADS=' + cpus.toString()]
   };
 
-  var info = gdal.suggestedWarpOutput(options);
+  try {
+    var info = gdal.suggestedWarpOutput(options);
+  } catch (err) {
+    throw new Error('GDAL Bounds Error ' + err.message);
+  }
 
   var creationOptions = [
     'TILED=YES',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wmtiff",
-  "version": "0.4.1",
+  "version": "0.4.2-dev",
   "description": "",
   "main": "index.js",
   "author": "Mapbox (https://www.mapbox.com)",


### PR DESCRIPTION
This PR adds error handlers for reprojection errors so these types of invalid uploads don't end up in the unpacker DL queue. See https://github.com/mapbox/unpacker/issues/1690 for more info. 

